### PR TITLE
added edit button using web.py and added index.html changes to suppor…

### DIFF
--- a/ToDo/backend/app.py
+++ b/ToDo/backend/app.py
@@ -1,11 +1,13 @@
 import os
 import web
 from db import db
+import json
 
 urls = (
     '/', 'Index',
     '/add', 'Add',
     '/toggle/(\\d+)', 'Toggle',
+    '/edit/(\\d+)', 'Edit',
     '/delete/(\\d+)', 'Delete'
 )
 
@@ -37,6 +39,16 @@ class Toggle:
             SET completed = NOT completed
             WHERE id = $id
         """, vars={'id': int(id)})
+        raise web.seeother('/')
+
+class Edit:
+    def POST(self, id):
+        data = web.input(title="")
+        title = data.title.strip()
+        if title:
+            db.update('tasks', where='id=$id', vars={'id': int(id)}, title=title)
+            if web.ctx.env.get('HTTP_X_REQUESTED_WITH'):  # If AJAX
+                return json.dumps({'status': 'ok', 'id': int(id), 'title': title})
         raise web.seeother('/')
 
 class Delete:

--- a/ToDo/backend/templates/index.html
+++ b/ToDo/backend/templates/index.html
@@ -41,7 +41,7 @@ $code:
         $for task in tasks:
           $code:
               cls = 'task-title completed' if task.completed else 'task-title'
-          <li>
+          <li data-id="$task.id">
             <div>
               <span class="$:cls">$task.title</span>
               <small>Created: $:fmt(task.created_at)</small>
@@ -49,6 +49,10 @@ $code:
             <div class="actions">
               <form action="/toggle/$task.id" method="POST" style="display:inline;">
                 <button type="submit" class="btn-primary">$:('Undo' if task.completed else 'Done')</button>
+              </form>
+              <form action="/edit/$task.id" method="POST" style="display:inline;">
+                <input type="text" name="title" value="$task.title" style="padding:6px; font-size:14px; margin-right:6px;">
+                <button type="submit" class="btn-primary">Edit</button>
               </form>
               <form action="/delete/$task.id" method="POST" style="display:inline;">
                 <button type="submit" class="btn-danger">Delete</button>


### PR DESCRIPTION
# Add Edit Task Functionality

## Overview
This PR adds the ability to edit existing tasks in the ToDo application. The implementation follows the same simple pattern as the existing toggle and delete functionality, using standard HTML forms and POST requests.

## Changes

### `app.py`
- Added new `/edit/(\\d+)` route to handle task updates
- Implemented `Edit` class with POST handler:
  
- Added route to `urls` tuple for handling edit requests

### `templates/index.html`
- Added edit form inline with existing toggle and delete buttons
- Each task now includes a form with:
  - Text input pre-filled with current task title
  - Edit button to submit changes
- Maintains consistent styling with existing buttons
- Uses same form-based pattern as toggle/delete for simplicity
